### PR TITLE
Html mail theme default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Changed RSS feeds view from rendered entity to fields for better control.
 - Remove untranslated nodes from sitemap.xml
+- Use default theme for sending HTML mails.
 
 ## [1.11.0] - 06-11-2017
 ### Changed

--- a/degov_html_mail/config/install/mailsystem.settings.yml
+++ b/degov_html_mail/config/install/mailsystem.settings.yml
@@ -1,4 +1,4 @@
-theme: current
+theme: default
 defaults:
   sender: swiftmailer
   formatter: swiftmailer

--- a/degov_html_mail/config/update_8001/rewrite/mailsystem.settings.yml
+++ b/degov_html_mail/config/update_8001/rewrite/mailsystem.settings.yml
@@ -1,0 +1,1 @@
+theme: default

--- a/degov_html_mail/degov_html_mail.install
+++ b/degov_html_mail/degov_html_mail.install
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * Send HTML mails using default theme.
+ */
+function degov_html_mail_update_8001() {
+  \Drupal::service('degov_config.module_updater')
+    ->applyUpdates('degov_html_mail', '8001');
+}


### PR DESCRIPTION
When sending a test newsletter, the current theme is the backend theme and the newsletter is rendered using the backend theme. In order to render it with the frontend theme, the mailsystem settings should configure sending mails using the default theme.