### PR TITLE
Allow only paging with next/previous buttons on the calendar widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.15.1] - IN DEVELOPMENT
 ### Changes 
-- Allow override of javascript behaviours in the theme. 
+- Allow override of javascript behaviours in the theme.
+- Calendar widget paging for events will only work as a pager not as a filter.
 
 ## [1.15.0] - 16-02-2018 
 ### Fixed

--- a/degov_node_event/config/install/views.view.events.yml
+++ b/degov_node_event/config/install/views.view.events.yml
@@ -640,6 +640,10 @@ display:
           plugin_id: view
       defaults:
         header: false
+        use_ajax: false
+        arguments: false
+      use_ajax: true
+      arguments: {  }
     cache_metadata:
       max-age: -1
       contexts:

--- a/degov_node_event/config/update_8012/rewrite/views.view.events.yml
+++ b/degov_node_event/config/update_8012/rewrite/views.view.events.yml
@@ -1,0 +1,8 @@
+display:
+  events_page_list:
+    display_options:
+      defaults:
+        use_ajax: false
+        arguments: false
+      use_ajax: true
+      arguments: {  }

--- a/degov_node_event/degov_node_event.install
+++ b/degov_node_event/degov_node_event.install
@@ -21,9 +21,8 @@ function degov_node_event_uninstall() {
 }
 
 /**
- * Next module update version is 8012.
- * All update hooks from 1.1 to 1.15 were deleted.
- * There is no upgrade path from 1.1 to 1.15, you need first to update to 1.2
- * and every minor release as well until 1.15 respectively.
- * The fresh install should have all the changes from 1.1 to 1.15.
+ * Update calendar widget to use ajax pagers without view filter.
  */
+function degov_node_event_update_8012() {
+  \Drupal::service('degov_config.module_updater')->applyUpdates('degov_node_event', '8012');
+}


### PR DESCRIPTION
Calendar widget paging for events will only work as a pager not as a filter.

This is the case for events in /veranstaltungen

For testing:
 - Page through other months, the view should not filter anything while browsing other months
 - Clicking a date should still filter the view