### PR TITLE
Display published press articles in the press calendar widget and add…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [1.15.1] - IN DEVELOPMENT
+### Fixed
+- Display all published press articles in the press calendar widget.
+- Add linkable press articles from the press calendar widget.
+- Display the correct press date in the press teaser display.
+
 ### Changes 
 - Allow override of javascript behaviours in the theme.
 - Calendar widget paging for events will only work as a pager not as a filter.

--- a/degov_node_event/js/events.js
+++ b/degov_node_event/js/events.js
@@ -8,7 +8,7 @@
   'use strict';
 
   /**
-   * Hide/shows a FAQ paragraph text by clicking on the title.
+   * Fills the date filters on calendar widget click and submits the form.
    */
   Drupal.behaviors.degov_events = {
     attach: function (context, settings) {

--- a/degov_node_press/config/install/views.view.press_dates.yml
+++ b/degov_node_press/config/install/views.view.press_dates.yml
@@ -1,4 +1,3 @@
-uuid: e5b0a21a-1ae0-4597-bf65-64d7c6e78594
 langcode: de
 status: true
 dependencies:
@@ -15,8 +14,6 @@ dependencies:
     - degov_node_press
     - node
     - user
-_core:
-  default_config_hash: KKaEj5BmvoPHbJvdd9ARDb_w-gsenrWXpzAZwb12ouk
 id: press_dates
 label: Pressetermine
 module: views
@@ -229,7 +226,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          operator: '>='
+          operator: '>'
           value:
             min: ''
             max: ''
@@ -324,7 +321,7 @@ display:
           exposed: false
           expose:
             label: ''
-          granularity: minute
+          granularity: second
           plugin_id: datetime
       title: Pressetermine
       header: {  }
@@ -713,6 +710,10 @@ display:
           plugin_id: view
       defaults:
         header: false
+        use_ajax: false
+        filters: true
+        filter_groups: true
+      use_ajax: true
     cache_metadata:
       max-age: -1
       contexts:

--- a/degov_node_press/config/update_8012/rewrite/views.view.press_dates.yml
+++ b/degov_node_press/config/update_8012/rewrite/views.view.press_dates.yml
@@ -1,0 +1,16 @@
+display:
+  default:
+    display_options:
+      filters:
+        field_press_date_value:
+          operator: '>'
+      sorts:
+        field_press_date_value:
+          granularity: second
+  press_page_list:
+    display_options:
+      defaults:
+        use_ajax: false
+        filters: true
+        filter_groups: true
+      use_ajax: true

--- a/degov_node_press/css/press.css
+++ b/degov_node_press/css/press.css
@@ -1,0 +1,4 @@
+.calendar-calendar .has-events {
+  text-decoration: underline;
+  cursor: pointer;
+}

--- a/degov_node_press/degov_node_press.install
+++ b/degov_node_press/degov_node_press.install
@@ -20,3 +20,10 @@ function degov_node_press_uninstall() {
  * and every minor release as well until 1.15 respectively.
  * The fresh install should have all the changes from 1.1 to 1.15.
  */
+
+/**
+ * Fixes press calendar widget so it will show published press articles.
+ */
+function degov_node_press_update_8012() {
+  \Drupal::service('degov_config.module_updater')->applyUpdates('degov_node_press', '8012');
+}

--- a/degov_node_press/degov_node_press.libraries.yml
+++ b/degov_node_press/degov_node_press.libraries.yml
@@ -4,3 +4,15 @@ slider:
     js/slider.js: {}
   dependencies:
     - degov_common/slick
+degov_press:
+  version: 1.0
+  js:
+    js/press.js: { }
+  css:
+    theme:
+      css/press.css: {}
+  dependencies:
+    - core/jquery
+    - core/drupal
+    - core/drupalSettings
+    - core/jquery.once

--- a/degov_node_press/degov_node_press.module
+++ b/degov_node_press/degov_node_press.module
@@ -23,4 +23,14 @@ function degov_node_press_views_pre_render(ViewExecutable $view) {
   if (isset($view) && ($view->storage->id() == 'press_latest_content')) {
     $view->element['#attached']['library'][] = 'degov_node_press/slider';
   }
+  // Load the press library for additional functionality in the calendar widget.
+  if ($view->storage->id() == 'press_dates' && $view->current_display == 'press_calendar_widget') {
+    $view->element['#attached']['library'][] = 'degov_node_press/degov_press';
+    // Add the path to the press listings page in the drupalSettings.
+    $display_handler = $view->displayHandlers->get($view->display_handler->options['link_display'])->getRoutedDisplay();
+    if (!empty($display_handler)) {
+      $path = $display_handler->getPath();
+      $view->element['#attached']['drupalSettings']['degov_node_press']['path'] = $path;
+    }
+  }
 }

--- a/degov_node_press/js/press.js
+++ b/degov_node_press/js/press.js
@@ -1,0 +1,59 @@
+/**
+ * @file press.js
+ *
+ * Defines the behavior of the calendar widget.
+ */
+(function ($, Drupal, drupalSettings) {
+
+  'use strict';
+
+  /**
+   * deGov node press functionality related to the press calendar widget.
+   */
+  Drupal.behaviors.degov_press = {
+    attach: function (context, settings) {
+      // Skip the behavior in case no calendar widget has been found on the page.
+      if ($('.calendar-calendar', context).length == 0) {
+        return;
+      }
+
+      /**
+       * Fills the date filters on calendar widget click and submits the form.
+       */
+      $('.has-events .mini-day-on', context).click(function(){
+        var view_wrapper = $(this).closest('.view-display-id-press_page_list');
+        var dates = getFromToDates(this);
+        $('input[name="from"]', view_wrapper).val(dates.from);
+        $('input[name="to"]', view_wrapper).val(dates.to);
+        $('form', view_wrapper).submit();
+      });
+
+      /**
+       *  Redirect to the press listings page when clicking the calendar widget.
+       */
+      $('.has-events .mini-day-on', context).click(function() {
+        var path = settings.degov_node_press.path;
+        var dates = getFromToDates(this);
+        window.location.replace(path + "?from=" + dates.from + "&to=" + dates.to);
+      });
+
+      /**
+       * Returns an object with from and to date extracted from the calendar widget.
+       *
+       * @param element
+       *   Clicked date element in the calendar widget.
+       *
+       * @returns {{from: string, to: string}}
+       */
+      function getFromToDates(element) {
+        var parent = $(element).parent();
+        var fromDate = parent.attr('id').replace('press_dates-', '');
+        var toDate = new Date(fromDate);
+        toDate.setDate(toDate.getDate() + 1);
+        toDate = toDate.toISOString().substr(0, 10);
+        return {from: fromDate, to: toDate};
+      }
+    }
+  }
+
+})(jQuery, Drupal, drupalSettings);

--- a/degov_node_press/templates/node--press--teaser.html.twig
+++ b/degov_node_press/templates/node--press--teaser.html.twig
@@ -91,7 +91,7 @@
   {{ title_suffix }}
 
   <div class="press__teaser-date-left teaser-date col-xs-5 col-sm-4 col-md-3">
-        <div class="event__teaser__day">{{ node.field_event_date.value|date('d') }}</div>
+    <div class="press__teaser__day">{{ node.field_press_date.value|date('d') }}</div>
   </div>
 
   <div class="press__teaser-content teaser-content col-xs-7 col-sm-8 col-md-9"> <!-- from medium screen up, show on the right sidebar -->


### PR DESCRIPTION
Currently the press calendar widget was not correctly working as published press articles were not shown. Also it is possible to include the press calendar widget individually on a page. However, there was no included functionality yet. 

This PR will:
 - Show published press on the calendar widget in the search and calendar widget block.
 - Fix press filters and add javascript for filtering on using the calendar widget.
 - Add redirection to the press listing page when the press calendar widget block is used on a page.